### PR TITLE
Fixed double word 'properly' in error message

### DIFF
--- a/Corcav.Behaviors/Library/EventToCommand.cs
+++ b/Corcav.Behaviors/Library/EventToCommand.cs
@@ -131,7 +131,7 @@ namespace Corcav.Behaviors
 				if (this.Command == null) this.CreateRelativeBinding();
 			}
 
-			if (this.Command == null) throw new InvalidOperationException("No command available, Is Command properly properly set up?");
+			if (this.Command == null) throw new InvalidOperationException("No command available, Is Command properly set up?");
 
 			if (this.Command.CanExecute(this.CommandParameter))
 			{


### PR DESCRIPTION
simply just that :)
