### PR TITLE
Fixed issue that can cause Events to crash without Args specified in Command

### DIFF
--- a/Corcav.Behaviors/Library/EventToCommand.cs
+++ b/Corcav.Behaviors/Library/EventToCommand.cs
@@ -148,7 +148,7 @@ namespace Corcav.Behaviors
         /// <param name="e">The EventArgs value accompanying the Event</param>
         private void OnFired(EventArgs e)
 		{
-            object returnParam = this.CommandParameter ?? e;
+            object returnParam = e ?? this.CommandParameter;
 
             if (!string.IsNullOrEmpty(this.CommandName))
 			{
@@ -156,6 +156,8 @@ namespace Corcav.Behaviors
 			}
 
 			if (this.Command == null) throw new InvalidOperationException("No command available, Is Command properly set up?");
+
+			if (e == null && this.CommandParameter == null) throw new InvalidOperationException("You need a CommandParameter");
 
 			if (this.Command.CanExecute(returnParam))
 			{


### PR DESCRIPTION
Fixed issue that can cause crashing when Commands are set up to not pass in EventArgs, but solely to trigger on a specific event. For example, if you have a Command that is triggering on ItemSelected, but you don't actually want to pass in the ItemSelected EventArg into your Command, it will crash without this.
